### PR TITLE
Add basic scroll-timeline page

### DIFF
--- a/src/components/organisms/TimelineSpace.tsx
+++ b/src/components/organisms/TimelineSpace.tsx
@@ -1,0 +1,44 @@
+import React, { useMemo } from 'react'
+import { useThree, useFrame } from '@react-three/fiber'
+import { useScroll } from '@react-three/drei'
+import { useSpring, a } from '@react-spring/three'
+
+import { Stars } from '@/components/molecules/Stars'
+import GradientWall from '@/components/molecules/Wall'
+import { useThemeContext } from '@/hooks/useApp'
+
+const WALL = {
+  dark: ['#23262a', '#333639', '#202226', '#23262a'],
+  light: ['#fff', '#fff', '#fff', '#fff'],
+}
+const INTERVAL = 30
+
+export const TimelineSpace: React.FC<{ pages: number }> = ({ pages }) => {
+  const height = useThree(state => Math.floor(state.size.height / INTERVAL) * INTERVAL)
+  const { theme } = useThemeContext()
+  const data = useScroll()
+  const scrollMax = height * pages
+
+  const colorSet = useMemo(() => WALL[theme], [theme])
+  const [{ top }, set] = useSpring(() => ({ top: 0 }))
+  useFrame(() => set.start({ top: data.range(0, 1) * scrollMax }))
+
+  const starPosition = top.to(top => [0, -1 + top / 20, 0])
+  const trainPosition = top.to(top => [0, -top / 10, 0])
+  const wallColor = top.to([0, scrollMax * 0.25, scrollMax * 0.8, scrollMax], colorSet)
+
+  return (
+    <>
+      <GradientWall color={wallColor} />
+      <Stars position={starPosition} />
+      <a.group position={trainPosition}>
+        <mesh>
+          <boxGeometry args={[1, 1, 3]} />
+          <meshStandardMaterial color="orange" />
+        </mesh>
+      </a.group>
+    </>
+  )
+}
+
+export default TimelineSpace

--- a/src/components/templates/TimelinePage.tsx
+++ b/src/components/templates/TimelinePage.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import Head from 'next/head'
+import { Canvas } from '@react-three/fiber'
+import { ScrollControls, Scroll } from '@react-three/drei'
+
+import TimelineSpace from '@/components/organisms/TimelineSpace'
+import { bgColor } from '~/site-config'
+import { useThemes } from '@/hooks/useApp'
+
+export const TimelinePage: React.FC<{ pages: number; children: React.ReactNode }> = ({ pages, children }) => {
+  const { theme } = useThemes()
+
+  return (
+    <>
+      <Head>
+        <meta name="theme-color" content={bgColor[theme]} />
+      </Head>
+      <Canvas>
+        <ScrollControls damping={0.5} pages={pages}>
+          <Scroll>
+            <TimelineSpace pages={pages} />
+          </Scroll>
+          <Scroll html>
+            <div text="dark:white">{children}</div>
+          </Scroll>
+        </ScrollControls>
+      </Canvas>
+    </>
+  )
+}
+
+export default TimelinePage

--- a/src/data/timeline.ts
+++ b/src/data/timeline.ts
@@ -1,0 +1,11 @@
+export interface TimelineEvent {
+  year: number
+  title: string
+  description: string
+}
+
+export const timelineEvents: TimelineEvent[] = [
+  { year: 2021, title: 'Seongland 1.0', description: 'Legacy web version launched' },
+  { year: 2022, title: 'Seongland 2.0', description: 'Added 3D starfield features' },
+  { year: 2024, title: 'Seongland 3.0', description: 'Cosmic timeline with train' },
+]

--- a/src/pages/timeline.tsx
+++ b/src/pages/timeline.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import { timelineEvents } from '@/data/timeline'
+import TimelinePage from '@/components/templates/TimelinePage'
+import { CenterPage } from '@/components/atoms/CenterPage'
+import { GridTitle } from '@/components/atoms/GridTitle'
+
+const PAGES = timelineEvents.length * 2
+
+const Timeline: React.FC = () => {
+  return (
+    <TimelinePage pages={PAGES}>
+      {timelineEvents.map((e, i) => (
+        <CenterPage key={i} page={i * 2 + 1} pages={PAGES}>
+          <GridTitle title={`${e.year} - ${e.title}`} />
+          <p>{e.description}</p>
+        </CenterPage>
+      ))}
+    </TimelinePage>
+  )
+}
+
+export default Timeline

--- a/test/page.test.tsx
+++ b/test/page.test.tsx
@@ -3,11 +3,28 @@ import { describe, vi, test } from 'vitest'
 import { render } from '@testing-library/react'
 
 import LandingPage, { getStaticProps } from '@/pages/index'
+import Timeline from '@/pages/timeline'
+
+declare global {
+  // eslint-disable-next-line no-var
+  var ResizeObserver: any
+}
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
 
 describe('Seongland Pages', () => {
   test('Landing Page', async () => {
     const { props } = await getStaticProps()
     const { unmount } = render(<LandingPage {...props} />)
+    unmount()
+  })
+
+  test('Timeline Page', () => {
+    const { unmount } = render(<Timeline />)
     unmount()
   })
 })


### PR DESCRIPTION
## Summary
- implement TimelineSpace and TimelinePage components
- create timeline data and a Next.js page to display events
- update tests to cover timeline page

## Testing
- `pnpm lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6842cc71f97c8327accce4ac8357f50f