### PR TITLE
Fix image overflow issue

### DIFF
--- a/src/components/atoms/SpringCard.tsx
+++ b/src/components/atoms/SpringCard.tsx
@@ -62,7 +62,6 @@ export const SpringCard: React.FC<{ card: Card; spring: SpringProp; props: DragP
               objectFit: 'cover',
               backgroundPosition: 'center center',
               scale: `${card.ratio}`,
-              overflow: 'clip',
               backgroundRepeat: 'no-repeat',
             }}
           />

--- a/src/components/atoms/SpringCard.tsx
+++ b/src/components/atoms/SpringCard.tsx
@@ -62,7 +62,7 @@ export const SpringCard: React.FC<{ card: Card; spring: SpringProp; props: DragP
               objectFit: 'cover',
               backgroundPosition: 'center center',
               scale: `${card.ratio}`,
-              overflow: 'visible',
+              overflow: 'clip',
               backgroundRepeat: 'no-repeat',
             }}
           />


### PR DESCRIPTION
## Why did you do this
- Browser warning flagged `overflow: visible` on images

## How did you do that
- Use `overflow: clip` for card images

------
https://chatgpt.com/codex/tasks/task_e_684cacc5977083279722cbaff0068eb3