### PR TITLE
Add alt property for MBTI card

### DIFF
--- a/scripts/cards.ts
+++ b/scripts/cards.ts
@@ -23,6 +23,7 @@ export interface Card {
   theme: string
   color: string
   ratio: string
+  alt?: string
   image: {
     src?: string
     height?: number
@@ -111,6 +112,7 @@ const webapps: Card[] = [
   {
     title: '',
     subtitle: '',
+    alt: 'MBTI GPT',
     url: 'https://mbti.texonom.com',
     theme: '#18171c',
     color: 'white',

--- a/src/components/atoms/SpringCard.tsx
+++ b/src/components/atoms/SpringCard.tsx
@@ -51,7 +51,7 @@ export const SpringCard: React.FC<{ card: Card; spring: SpringProp; props: DragP
           flex="col-reverse">
           <Image
             fill
-            alt={card.title}
+            alt={card.alt ?? card.title}
             src={card.image.src as string}
             placeholder="blur"
             blurDataURL={card.image.blurDataURL || card.image.src}


### PR DESCRIPTION
## Summary
- support optional `alt` text in `Card` type
- use new `alt` prop when rendering cards
- define alt text for the MBTI card while leaving title blank

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_684caca0cb54832780b8a299aff492f2