### PR TITLE
Add SpeedInsights support

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@react-three/fiber": "^8.18.0",
     "@use-gesture/react": "^10.3.1",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "copy": "^0.3.2",
     "dotenv": "^10.0.0",
     "next": "15.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@15.3.3(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(next@15.3.3(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       copy:
         specifier: ^0.3.2
         version: 0.3.2
@@ -1265,6 +1268,29 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@1.2.0':
+    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:
@@ -5008,6 +5034,11 @@ snapshots:
       react: 18.3.1
 
   '@vercel/analytics@1.5.0(next@15.3.3(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    optionalDependencies:
+      next: 15.3.3(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+
+  '@vercel/speed-insights@1.2.0(next@15.3.3(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
       next: 15.3.3(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import Router from 'next/router'
 import { ThemeProvider } from 'next-themes'
 
 import dynamic from 'next/dynamic'
+import { SpeedInsights } from '@vercel/speed-insights/next'
 
 const GA4 = dynamic(() => import('@/components/atoms/GA4'), { ssr: false })
 const Analytics = dynamic(() => import('@vercel/analytics/react').then(m => m.Analytics), { ssr: false })
@@ -55,6 +56,7 @@ function App(props: AppProps) {
       </ThemeProvider>
       {process.env.NEXT_PUBLIC_VERCEL_URL ? <Analytics /> : <></>}
       {process.env.NEXT_PUBLIC_VERCEL_URL ? <GA4 id="G-CRRP8E78TC" /> : <></>}
+      {process.env.NEXT_PUBLIC_VERCEL_URL ? <SpeedInsights /> : <></>}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- conditionally render Vercel SpeedInsights in the app

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test` *(fails: watch mode was manually cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684f2702091c8327810dea945a26da27